### PR TITLE
Update builder to accommodate filenames that include folder numbers

### DIFF
--- a/lib/aspaceiiif/builder.rb
+++ b/lib/aspaceiiif/builder.rb
@@ -48,7 +48,9 @@ module ASpaceIIIF
     def generate_canvas(image_file, label, order)
       separator = image_file.include?('_') ? '_' : '.'
       image_id = image_file.chomp('.jp2').chomp('.tif').chomp('.tiff').chomp('.jpg')
-      page_id = image_id.split(separator).last
+      page_id_arr = image_id.split(separator)
+      # Use extended page_id for filenames that include a folder number
+      page_id_arr[-2].match(/^\d+$/) ? page_id = page_id_arr[-2] + '_' + page_id_arr[-1] : page_id = page_id_arr.last
 
       canvas_id = "#{@sequence_base}/canvas/#{page_id}"
 
@@ -84,7 +86,8 @@ module ASpaceIIIF
     def generate_range(image_file, label, order)
       separator = image_file.include?('_') ? '_' : '.'
       image_id = image_file.chomp('.jp2').chomp('.tif').chomp('.tiff').chomp('.jpg')
-      page_id = image_id.split(separator).last
+      page_id_arr = image_id.split(separator)
+      page_id_arr[-2].match(/^\d+$/) ? page_id = page_id_arr[-2] + '_' + page_id_arr[-1] : page_id = page_id_arr.last
 
       range_id = "#{@sequence_base}/range/r-#{order}"
       canvas_id = "#{@sequence_base}/canvas/#{page_id}"

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -73,7 +73,11 @@ describe ASpaceIIIF::Builder do
       expect(canvas["@type"]).to eq("sc:Canvas")
     end
 
-    it "includes folder number in canvas IDs" do
+    it "outputs a normal canvas ID" do
+      expect(canvas["@id"]).to eq("/canvas/0001")
+    end
+
+    it "includes folder number in canvas IDs when applicable" do
       expect(edge_case_canvas["@id"]).to eq("/canvas/001_001")
     end
   end
@@ -94,7 +98,11 @@ describe ASpaceIIIF::Builder do
       expect(range["@type"]).to eq("sc:Range")
     end
 
-    it "includes folder number in canvas IDs" do
+    it "ranges include a normal canvas ID" do
+      expect(range["canvases"][0]).to eq("/canvas/0001")
+    end
+
+    it "ranges include folder number canvas IDs when applicable" do
       expect(edge_case_range["canvases"][0]).to eq("/canvas/001_001")
     end
   end

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -1,8 +1,14 @@
 require 'aspaceiiif/builder'
 
 describe ASpaceIIIF::Builder do
+  # Japanese prints Chushingura used as example of standard manuscript dig obj
   let(:builder) { ASpaceIIIF::Builder.new('1596') }
   let(:metadata) { ASpaceIIIF::Metadata.new('1596') }
+
+  # CCC South Boston High School monitor reports used to test edge cases in which 
+  # the filename includes a folder number
+  let(:edge_case_builder) { ASpaceIIIF::Builder.new('1708') }
+  let(:edge_case_metadata) { ASpaceIIIF::Metadata.new('1708') }
 
   describe "#generate_manifest" do
     let(:manifest) { builder.generate_manifest }
@@ -61,9 +67,14 @@ describe ASpaceIIIF::Builder do
 
   describe "#generate_canvas" do
     let(:canvas) { builder.generate_canvas(metadata.filenames[0], metadata.filenames[0].chomp(".jp2"), 1) }
+    let(:edge_case_canvas) { edge_case_builder.generate_canvas(edge_case_metadata.filenames[0], edge_case_metadata.filenames[0].chomp(".jp2"), 1) }
 
     it "outputs a canvas" do
       expect(canvas["@type"]).to eq("sc:Canvas")
+    end
+
+    it "includes folder number in canvas IDs" do
+      expect(edge_case_canvas["@id"]).to eq("/canvas/001_001")
     end
   end
 
@@ -77,9 +88,14 @@ describe ASpaceIIIF::Builder do
 
   describe "#generate_range" do
     let(:range) { builder.generate_range(metadata.filenames[0], metadata.filenames[0].chomp(".jp2"), 1) }
+    let(:edge_case_range) { edge_case_builder.generate_range(edge_case_metadata.filenames[0], edge_case_metadata.filenames[0].chomp(".jp2"), 1) }
 
     it "outputs a range" do
       expect(range["@type"]).to eq("sc:Range")
+    end
+
+    it "includes folder number in canvas IDs" do
+      expect(edge_case_range["canvases"][0]).to eq("/canvas/001_001")
     end
   end
 end


### PR DESCRIPTION
### What does this PR do?
Tweaks the generate_canvas and generate_range methods such that canvas IDs are generated in the form \d+_\d+ if and only if the filename includes the folder number.

### Motivation and context
The filenames for the Citywide Coordinating Council South Boston High School monitor reports include the folder numbers, which causes a collision in canvas ID generation. For example, the following two components would both end up with the same canvas ID:

MS1990_031_ref998_001_001
MS1990_031_ref998_002_001

This causes multiple problems in Mirador, including a mismatch between the rendered canvas and its thumbnail.

### How has this been tested?
Wrote and passed tests in builder_spec, then generated manifests and views in the test environment that passed visual QC.

### How can a reviewer see the effects of these changes?
Rendered manifests for all CCC digital objects are viewable in the test environment.

### Related tickets
https://trello.com/c/8aAh3wuh/116-mismatch-between-thumbs-and-rendered-canvas-for-south-boston-high-school-monitor-reports

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have tested this code.
- [ ] This PR requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have stakeholder approval to make this change.
