### PR TITLE
Allow resource ID as input for batch generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # aspaceiiif
 
-Generates IIIF manifests and Mirador viewer HTML from an ArchivesSpace digital 
-object record. This gem is configured to support Boston College's IIIF implementation.
+Generates IIIF JSON manifests and HTML files instantiating Mirador (locally termed 
+'views') from an ArchivesSpace digital object record. This gem is configured to 
+support Boston College Libraries' IIIF implementation.
 
 ## Installation
 
@@ -19,19 +20,19 @@ build and install the gem:
     
 ## Usage
 
-To generate a manifest and HTML view file for a single digital object, pass the 
-digital object ID as an argument; e.g.:
+To generate a manifest and view for a single digital object, pass 
+'digital_object' and the digital object ID as arguments; e.g.:
 
-    $ aspaceiiif 1596
+    $ aspaceiiif digital_object 1596
 
-To generate manifests and HTML view files for multiple digital objects, put the 
-digital object IDs in a text file delimited by newlines, then pass that file as an 
-argument; e.g.:
+The gem can also generate manifests and views for all digital objects associated 
+with a resource record. To do this, pass 'resource' as the resource ID as 
+arguments, e.g.:
 
-    $ aspaceiiif dig-obj-ids.txt
+    $ aspaceiiif resource 166
 
-(Note: [export_dao_ids.rb](https://github.com/BCDigLib/bc-aspace/blob/master/techmd_dump/export_dao_ids.rb) can be used to generate a text file containing all
-digital object IDs associated with a given resource.)
+In either case, the gem will create two directories -- 'manifests' and 'views' -- 
+where it will write the output files.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ argument; e.g.:
 
     $ aspaceiiif dig-obj-ids.txt
 
+(Note: [export_dao_ids.rb](https://github.com/BCDigLib/bc-aspace/blob/master/techmd_dump/export_dao_ids.rb) can be used to generate a text file containing all
+digital object IDs associated with a given resource.)
+
 ## Development
 
 After checking out the repo, run `bundle exec rspec` to run the tests.

--- a/lib/aspaceiiif.rb
+++ b/lib/aspaceiiif.rb
@@ -16,7 +16,7 @@ module ASpaceIIIF
     end.parse!
 
     Dir.mkdir('manifests') unless File.exists?('manifests')
-    Dir.mkdir('view') unless File.exists?('view')
+    Dir.mkdir('views') unless File.exists?('views')
 
     input_type = ARGV[0]
     input_id = ARGV[1]
@@ -41,7 +41,7 @@ module ASpaceIIIF
         view_html = view_builder.build("manifests/#{manifest_fname}")
         view_fname = manifest_fname.chomp('.json')
 
-        f = File.new("view/#{view_fname}", 'w')
+        f = File.new("views/#{view_fname}", 'w')
         f.write(view_html)
         f.close
         puts "Created Mirador view for manifest #{manifest_fname}"
@@ -63,7 +63,7 @@ module ASpaceIIIF
       view_html = view_builder.build("manifests/#{manifest_fname}")
       view_fname = manifest_fname.chomp('.json')
 
-      f = File.new("view/#{view_fname}", 'w')
+      f = File.new("views/#{view_fname}", 'w')
       f.write(view_html)
       f.close
       puts "Created Mirador view for manifest #{manifest_fname}"

--- a/lib/aspaceiiif.rb
+++ b/lib/aspaceiiif.rb
@@ -6,7 +6,8 @@ require 'optparse'
 module ASpaceIIIF
   def self.run
     OptionParser.new do |parser|
-      parser.banner = "Usage: aspaceiiif [ digital_object_id | digital_object_ids.txt ]"
+      parser.banner = "Usage: aspaceiiif [ resource | digital_object ] [ id (db primary key) ]
+      e.g., aspaceiiif resource 15"
 
       parser.on("-h", "--help", "Show this help message") do ||
         puts parser
@@ -17,13 +18,13 @@ module ASpaceIIIF
     Dir.mkdir('manifests') unless File.exists?('manifests')
     Dir.mkdir('view') unless File.exists?('view')
 
-    input = ARGV[0]
+    input_type = ARGV[0]
+    input_id = ARGV[1]
 
-    if input.include?('.txt')
-      # If given a text file, attempt to generate views and manifests for 
-      # multiple digital object IDS in the file
-      inp_arr = File.readlines(input)
-      inp_arr.map { |id| id.strip! }.reject! { |id| id.empty? }
+    if input_type == 'resource'
+      # If given a resource ID, attempt to generate views and manifests for all 
+      # associated digital objects
+      inp_arr = APIUtils.new.find_digital_objects(input_id)
 
       inp_arr.each do |id|
         builder = ASpaceIIIF::Builder.new(id)
@@ -45,10 +46,9 @@ module ASpaceIIIF
         f.close
         puts "Created Mirador view for manifest #{manifest_fname}"
       end
-    else
-      # Given no text file, attempt to generate view and manifest for single 
-      # digital object
-      builder = ASpaceIIIF::Builder.new(input)
+    elsif input_type == 'digital_object'
+      # Attempt to generate view and manifest for single digital object
+      builder = ASpaceIIIF::Builder.new(input_id)
       manifest = builder.generate_manifest
       manifest_json = manifest.to_json(pretty: true)
       manifest_fname = manifest["@id"].split('/').last
@@ -57,7 +57,7 @@ module ASpaceIIIF
       f.write(manifest_json)
       f.close
 
-      puts "Created IIIF manifest #{manifest_fname} for digital object #{input}"
+      puts "Created IIIF manifest #{manifest_fname} for digital object #{input_id}"
 
       view_builder = ASpaceIIIF::ViewBuilder.new
       view_html = view_builder.build("manifests/#{manifest_fname}")

--- a/lib/aspaceiiif/api_utils.rb
+++ b/lib/aspaceiiif/api_utils.rb
@@ -19,5 +19,51 @@ module ASpaceIIIF
       response = RestClient.get(endpoint, {"X-ArchivesSpace-Session": @session_id})
       JSON.parse(response)
     end
+
+    def find_digital_objects(resource_id)
+      resource_tree_uri_suffix = '/repositories/2/resources/' + resource_id + '/tree'
+      resource_tree = get_record(resource_tree_uri_suffix)
+
+      archival_object_refs = []
+      digital_object_refs = []
+
+      # TODO: refactor for efficiency
+      resource_tree["children"].map do |child|
+        if child["has_children"] == true
+          child["children"].map do |child|
+            archival_object_refs << child["record_uri"] if child["instance_types"].include?("digital_object")
+            if child["has_children"] == true
+              child["children"].map do |child|
+                archival_object_refs << child["record_uri"] if child["instance_types"].include?("digital_object")
+                if child["has_children"] == true
+                  child["children"].map do |child|
+                    archival_object_refs << child["record_uri"] if child["instance_types"].include?("digital_object")
+                    if child["has_children"] == true
+                      child["children"].map do |child|
+                        archival_object_refs << child["record_uri"] if child["instance_types"].include?("digital_object")
+                        if child["has_children"] == true
+                          child["children"].map do |child|
+                            archival_object_refs << child["record_uri"] if child["instance_types"].include?("digital_object")
+                          end
+                        end
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+        elsif child["instance_types"].include?("digital_object")
+          archival_object_refs << child["record_uri"] if child["instance_types"].include?("digital_object")
+        end
+      end
+
+      archival_object_refs.map do |ref|
+        archival_object = get_record(ref)
+        archival_object["instances"].map { |instance| digital_object_refs << instance["digital_object"]["ref"] if instance["instance_type"] == "digital_object" }
+      end
+
+      digital_object_refs.map { |ref| ref.split('/').last }
+    end
   end
 end

--- a/spec/api_utils_spec.rb
+++ b/spec/api_utils_spec.rb
@@ -1,14 +1,24 @@
 require 'aspaceiiif/api_utils'
 
 describe ASpaceIIIF::APIUtils do
+  let(:conn) { ASpaceIIIF::APIUtils.new }
 
   describe "#get_record(uri_suffix)" do
-    let(:conn) { ASpaceIIIF::APIUtils.new }
-
     context "given a valid endpoint" do
       it "returns a hash" do
         expect(conn.get_record('/repositories/2/digital_objects/1596')).to be_a(Hash)
       end
+    end
+  end
+
+  describe "#find_digital_objects(resource_id)" do
+    it "returns an array" do
+      expect(conn.find_digital_objects('122')).to be_a(Array)
+    end
+
+    it "finds all associated digital objects" do
+      expect(conn.find_digital_objects('122').length).to eq(7)
+      expect(conn.find_digital_objects('122')).to eq(['1703', '1704', '1705', '1706', '1707', '1708', '1709'])
     end
   end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### What does this PR do?
Adds resource ID as an optional input. When the user invokes aspaceiiif with the 'resource' arg (e.g., aspaceiiif resource 166), it finds all digital objects associated with that resource and generates manifests and views for them. Users can still create a manifest and view for a single digital object by passing the 'digital_object' arg (e.g., aspaceiiif digital_object 1708).

### Motivation and context
Our previous method of batch-creating manifests was to pass a text file containing digital object IDs to aspaceiiif. This required running a separate script that located the IDs of all digital objects associated with a given resource. Incorporating this functionality into aspaceiiif reduces complexity in the manifest generation workflow.

### How has this been tested?
Added tests for the new method used (find_digital_objects). These can be seen in spec/api_utils_spec.rb.

### How can a reviewer see the effects of these changes?
Pull the dev branch, install (or reinstall) the gem per the instructions in the readme, and invoke the gem on a digital object and a resource.

### Related tickets
https://github.com/BCDigLib/aspace-to-iiif/issues/1

### Screenshots
<!-- Include relevant screenshots if necessary -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have tested this code.
- [x] This PR requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have stakeholder approval to make this change.
