### PR TITLE
More bug fixes to builder re: page_id

### DIFF
--- a/lib/aspaceiiif/builder.rb
+++ b/lib/aspaceiiif/builder.rb
@@ -50,7 +50,7 @@ module ASpaceIIIF
       image_id = image_file.chomp('.jp2').chomp('.tif').chomp('.tiff').chomp('.jpg')
       page_id_arr = image_id.split(separator)
       # Use extended page_id for filenames that include a folder number
-      page_id_arr[-2].match(/^\d+$/) ? page_id = page_id_arr[-2] + '_' + page_id_arr[-1] : page_id = page_id_arr.last
+      page_id_arr[-2].match(/^\d{2}$|^\d{3}$/) ? page_id = page_id_arr[-2] + '_' + page_id_arr[-1] : page_id = page_id_arr.last
 
       canvas_id = "#{@sequence_base}/canvas/#{page_id}"
 
@@ -87,7 +87,7 @@ module ASpaceIIIF
       separator = image_file.include?('_') ? '_' : '.'
       image_id = image_file.chomp('.jp2').chomp('.tif').chomp('.tiff').chomp('.jpg')
       page_id_arr = image_id.split(separator)
-      page_id_arr[-2].match(/^\d+$/) ? page_id = page_id_arr[-2] + '_' + page_id_arr[-1] : page_id = page_id_arr.last
+      page_id_arr[-2].match(/^\d{2}$|^\d{3}$/) ? page_id = page_id_arr[-2] + '_' + page_id_arr[-1] : page_id = page_id_arr.last
 
       range_id = "#{@sequence_base}/range/r-#{order}"
       canvas_id = "#{@sequence_base}/canvas/#{page_id}"

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -1,14 +1,21 @@
 require 'aspaceiiif/builder'
 
 describe ASpaceIIIF::Builder do
-  # Japanese prints Chushingura used as example of standard manuscript dig obj
-  let(:builder) { ASpaceIIIF::Builder.new('1596') }
-  let(:metadata) { ASpaceIIIF::Metadata.new('1596') }
+  # Japanese prints Chushingura used as example of standard dig obj for legacy 
+  # manuscript collections
+  let(:legacy_builder) { ASpaceIIIF::Builder.new('1596') }
+  let(:legacy_metadata) { ASpaceIIIF::Metadata.new('1596') }
 
   # CCC South Boston High School monitor reports used to test edge cases in which 
   # the filename includes a folder number
   let(:edge_case_builder) { ASpaceIIIF::Builder.new('1708') }
   let(:edge_case_metadata) { ASpaceIIIF::Metadata.new('1708') }
+
+  # Newer digital objects use the archival object PK instead of a ref number in
+  # their component unique IDs. Here we are using a digital object from the 
+  # Joseph J. Williams ethnological collection as our standard test fixture.
+  let(:builder) { ASpaceIIIF::Builder.new('1746') }
+  let(:metadata) { ASpaceIIIF::Metadata.new('1746') }
 
   describe "#generate_manifest" do
     let(:manifest) { builder.generate_manifest }
@@ -74,7 +81,7 @@ describe ASpaceIIIF::Builder do
     end
 
     it "outputs a normal canvas ID" do
-      expect(canvas["@id"]).to eq("/canvas/0001")
+      expect(canvas["@id"]).to eq("/canvas/0000")
     end
 
     it "includes folder number in canvas IDs when applicable" do
@@ -99,7 +106,7 @@ describe ASpaceIIIF::Builder do
     end
 
     it "ranges include a normal canvas ID" do
-      expect(range["canvases"][0]).to eq("/canvas/0001")
+      expect(range["canvases"][0]).to eq("/canvas/0000")
     end
 
     it "ranges include folder number canvas IDs when applicable" do


### PR DESCRIPTION
### What does this PR do?
Adds more granular rules to how page_id is derived from the component unique IDs.

### Motivation and context
Some component unique IDs and/or digital object titles include an a number that indicates a physical folder or different collections processed from the same accession. We accommodated these in #3, but needed also to address CUIDs that include a primary key. This PR updates the test suite and builder to include all legacy and modern CUID/DO naming conventions:

Legacy methods:
Ref number; e.g., MS2013_043_ref15
Ref number + folder number; e.g., MS1990_031_ref998_001

Modern methods:
PK; e.g., MS2009_030_62973
Accession number + PK; e.g., MS1986_085_001_110282

Note that this will require further refinement when we begin generating manifests for AV content, as those DOs have unique naming conventions.

### How has this been tested?
Updated rspec test suite and generated manifests for sample DOs representing each naming convention.

### How can a reviewer see the effects of these changes?
Clone the repo, build/install the gem, and run `aspaceiiif digital_object ##` or `aspaceiiif resource ##`, where `##` is the primary key of the resource or digital object.

### Related tickets
#3 

### Screenshots
<!-- Include relevant screenshots if necessary -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have tested this code.
- [ ] This PR requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have stakeholder approval to make this change.
