### PR TITLE
Updates to filename filtering

### DIFF
--- a/lib/aspaceiiif.rb
+++ b/lib/aspaceiiif.rb
@@ -5,6 +5,8 @@ require 'optparse'
 
 module ASpaceIIIF
   def self.run
+    ARGV << "-h" if ARGV.empty? || ARGV[0] != ("digital_object" || "resource")
+
     OptionParser.new do |parser|
       parser.banner = "Usage: aspaceiiif [ resource | digital_object ] [ id (db primary key) ]
       e.g., aspaceiiif resource 15"
@@ -41,7 +43,7 @@ module ASpaceIIIF
         view_html = view_builder.build("manifests/#{manifest_fname}")
         view_fname = manifest_fname.chomp('.json')
 
-        f = File.new("views/#{view_fname}", 'w')
+        f = File.new("view/#{view_fname}", 'w')
         f.write(view_html)
         f.close
         puts "Created Mirador view for manifest #{manifest_fname}"
@@ -63,7 +65,7 @@ module ASpaceIIIF
       view_html = view_builder.build("manifests/#{manifest_fname}")
       view_fname = manifest_fname.chomp('.json')
 
-      f = File.new("views/#{view_fname}", 'w')
+      f = File.new("view/#{view_fname}", 'w')
       f.write(view_html)
       f.close
       puts "Created Mirador view for manifest #{manifest_fname}"

--- a/lib/aspaceiiif/builder.rb
+++ b/lib/aspaceiiif/builder.rb
@@ -45,12 +45,17 @@ module ASpaceIIIF
       manifest
     end
 
-    def generate_canvas(image_file, label, order)
+    def parse_sequence_number(image_file)
       separator = image_file.include?('_') ? '_' : '.'
       image_id = image_file.chomp('.jp2').chomp('.tif').chomp('.tiff').chomp('.jpg')
       page_id_arr = image_id.split(separator)
+      
       # Use extended page_id for filenames that include a folder number
-      page_id_arr[-2].match(/^\d{2}$|^\d{3}$/) ? page_id = page_id_arr[-2] + '_' + page_id_arr[-1] : page_id = page_id_arr.last
+      page_id_arr[-2].match(/^\d{2}$|^\d{3}$/) ? page_id_arr[-2] + '_' + page_id_arr[-1] : page_id_arr.last
+    end
+
+    def generate_canvas(image_file, label, order)
+      page_id = parse_sequence_number(image_file)
 
       canvas_id = "#{@sequence_base}/canvas/#{page_id}"
 
@@ -84,10 +89,7 @@ module ASpaceIIIF
     end
 
     def generate_range(image_file, label, order)
-      separator = image_file.include?('_') ? '_' : '.'
-      image_id = image_file.chomp('.jp2').chomp('.tif').chomp('.tiff').chomp('.jpg')
-      page_id_arr = image_id.split(separator)
-      page_id_arr[-2].match(/^\d{2}$|^\d{3}$/) ? page_id = page_id_arr[-2] + '_' + page_id_arr[-1] : page_id = page_id_arr.last
+      page_id = parse_sequence_number(image_file)
 
       range_id = "#{@sequence_base}/range/r-#{order}"
       canvas_id = "#{@sequence_base}/canvas/#{page_id}"

--- a/lib/aspaceiiif/metadata.rb
+++ b/lib/aspaceiiif/metadata.rb
@@ -62,6 +62,8 @@ module ASpaceIIIF
       # First delete the color target component
       @digital_object_components.delete_if { |comp| comp["title"].include?('_target') }
 
+      @digital_object_components.delete_if { |comp| comp["title"].include?('_INT') }
+
       @digital_object_components.map do |comp|
         if comp["file_versions"][0]["use_statement"].include?("master") || comp["file_versions"][0]["use_statement"].include?("archive")
           if comp["file_versions"][0]["file_uri"].include?('://')

--- a/lib/aspaceiiif/metadata.rb
+++ b/lib/aspaceiiif/metadata.rb
@@ -67,6 +67,8 @@ module ASpaceIIIF
           if comp["file_versions"][0]["file_uri"].include?('://')
             fname = comp["file_versions"][0]["file_uri"].split('/').last
             fname.chomp('.jpg').chomp('.tif').chomp('.jp2') + '.jp2'
+          elsif comp["file_versions"][0]["file_uri"].include?('_MAS')
+            comp["file_versions"][0]["file_uri"].chomp('.jpg').chomp('.tif').chomp('.jp2').chomp('_MAS') + '.jp2'
           else
             comp["file_versions"][0]["file_uri"].chomp('.jpg').chomp('.tif').chomp('.jp2') + '.jp2'
           end

--- a/lib/aspaceiiif/metadata.rb
+++ b/lib/aspaceiiif/metadata.rb
@@ -62,8 +62,12 @@ module ASpaceIIIF
       # First delete the color target component
       @digital_object_components.delete_if { |comp| comp["title"].include?('_target') }
 
+      # Next, remove intermediates so we don't end up with duplicate filenames
       @digital_object_components.delete_if { |comp| comp["title"].include?('_INT') }
 
+      # Finally, reverse-engineer image filenames based on file_uri data. This 
+      # handles several edge cases in our metadata and will require updating 
+      # once those are normalized
       @digital_object_components.map do |comp|
         if comp["file_versions"][0]["use_statement"].include?("master") || comp["file_versions"][0]["use_statement"].include?("archive")
           if comp["file_versions"][0]["file_uri"].include?('://')

--- a/spec/metadata_spec.rb
+++ b/spec/metadata_spec.rb
@@ -67,6 +67,8 @@ describe ASpaceIIIF::Metadata do
   end
 
   describe "#filenames" do
+    let(:multiple_manifestations) { ASpaceIIIF::Metadata.new('2219') }
+
     it "returns an array" do 
       expect(metadata.filenames).to be_instance_of(Array)
       expect(metadata.filenames.length).to be > 0
@@ -78,6 +80,11 @@ describe ASpaceIIIF::Metadata do
 
     it "contains no duplicates" do
       expect(metadata.filenames.uniq == metadata.filenames).to be true
+    end
+
+    it "does not include manifestation indicators in the filenames" do
+      expect(multiple_manifestations.filenames.any? { |fname| fname.include?('_INT') }).to be false
+      expect(multiple_manifestations.filenames.any? { |fname| fname.include?('_MAS') }).to be false
     end
   end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### What does this PR do?
Updates Metadata#filenames method to account for digital objects with intermediate and master manifestations. Also refactors sequence parsing in the Builder class to a new method, parse_sequence_number.

### Motivation and context
Sequence parsing is for DRY reasons, as the code was repeated in the generate_canvas and generate_range methods. The changes to filename parsing are required to filter out the _INT and _MAS suffixes currently included in some file_uris. (See digital object 2219 in ArchivesSpace for an example of this).

This may be a temporary change, as we are reconsidering how we model digital objects with intermediate manifestations.

### How has this been tested?
Added test coverage to spec/metadata_spec.rb and ran successfully on resource 445 (Karp collection). Also ran on resource 451, which contains DOs without intermediates, to confirm no unintended effects on conventional DOs.

### How can a reviewer see the effects of these changes?
Clone the repo, build and install the gem, then run it on a collection with intermediates; e.g., `aspaceiiif resource 445`

### Related tickets
#7 

### Screenshots
<!-- Include relevant screenshots if necessary -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have tested this code.
- [ ] This PR requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have stakeholder approval to make this change.
