### PR TITLE
Use component labels and file URIs to construct canvases and ranges

### DIFF
--- a/lib/aspaceiiif.rb
+++ b/lib/aspaceiiif.rb
@@ -5,7 +5,7 @@ require 'optparse'
 
 module ASpaceIIIF
   def self.run
-    ARGV << "-h" if ARGV.empty? || ARGV[0] != ("digital_object" || "resource")
+    ARGV << "-h" if ARGV.empty? || (ARGV[0] != "digital_object" && ARGV[0] != "resource")
 
     OptionParser.new do |parser|
       parser.banner = "Usage: aspaceiiif [ resource | digital_object ] [ id (db primary key) ]

--- a/lib/aspaceiiif.rb
+++ b/lib/aspaceiiif.rb
@@ -18,7 +18,7 @@ module ASpaceIIIF
     end.parse!
 
     Dir.mkdir('manifests') unless File.exists?('manifests')
-    Dir.mkdir('views') unless File.exists?('views')
+    Dir.mkdir('view') unless File.exists?('view')
 
     input_type = ARGV[0]
     input_id = ARGV[1]

--- a/lib/aspaceiiif/builder.rb
+++ b/lib/aspaceiiif/builder.rb
@@ -19,8 +19,8 @@ module ASpaceIIIF
       sequence = IIIF::Presentation::Sequence.new
       range = IIIF::Presentation::Range.new
 
-      sequence.canvases = metadata.component_labels_filenames.each_with_index { |comp, i| generate_canvas(comp[0], comp[1], i) }
-      range.ranges = metadata.component_labels_filenames.each_with_index { |comp, i| generate_range(comp[0], comp[1], i) }
+      sequence.canvases = metadata.component_labels_filenames.map.with_index { |comp, i| generate_canvas(comp[0], comp[1], i) }
+      range.ranges = metadata.component_labels_filenames.map.with_index { |comp, i| generate_range(comp[0], comp[1], i) }
 
       seed = {
           '@id' => "#{@manifest_server}/#{metadata.component_id}.json",

--- a/lib/aspaceiiif/builder.rb
+++ b/lib/aspaceiiif/builder.rb
@@ -19,8 +19,8 @@ module ASpaceIIIF
       sequence = IIIF::Presentation::Sequence.new
       range = IIIF::Presentation::Range.new
 
-      sequence.canvases = metadata.component_labels.each_with_index { |comp, i| generate_canvas(comp[0], comp[1], i) }
-      range.ranges = metadata.component_labels.each_with_index { |comp, i| generate_range(comp[0], comp[1], i) }
+      sequence.canvases = metadata.component_labels_filenames.each_with_index { |comp, i| generate_canvas(comp[0], comp[1], i) }
+      range.ranges = metadata.component_labels_filenames.each_with_index { |comp, i| generate_range(comp[0], comp[1], i) }
 
       seed = {
           '@id' => "#{@manifest_server}/#{metadata.component_id}.json",

--- a/lib/aspaceiiif/builder.rb
+++ b/lib/aspaceiiif/builder.rb
@@ -19,8 +19,8 @@ module ASpaceIIIF
       sequence = IIIF::Presentation::Sequence.new
       range = IIIF::Presentation::Range.new
 
-      sequence.canvases = metadata.filenames.map.with_index { |comp, i| generate_canvas("#{comp}", "#{comp.chomp('.jp2')}", i) }
-      range.ranges = metadata.filenames.map.with_index { |comp, i| generate_range("#{comp}", "#{comp.chomp('.jp2')}", i) }
+      sequence.canvases = metadata.component_labels.map.with_index { |comp, i| generate_canvas("#{comp}", "#{comp.chomp('.jp2')}", i) }
+      range.ranges = metadata.component_labels.map.with_index { |comp, i| generate_range("#{comp}", "#{comp.chomp('.jp2')}", i) }
 
       seed = {
           '@id' => "#{@manifest_server}/#{metadata.component_id}.json",

--- a/lib/aspaceiiif/builder.rb
+++ b/lib/aspaceiiif/builder.rb
@@ -45,16 +45,17 @@ module ASpaceIIIF
       manifest
     end
 
-    def parse_sequence_number(label)
-      separator = label.include?('_') ? '_' : '.'
-      page_id_arr = label.split(separator)
+    def parse_sequence_number(image_file)
+      base_fname = image_file.chomp('.jp2')
+      separator =  base_fname.include?('_') ? '_' : '.'
+      page_id_arr = base_fname.split(separator)
       
       # Use extended page_id for filenames that include a folder number
       page_id_arr[-2].match(/^\d{2}$|^\d{3}$/) ? page_id_arr[-2] + '_' + page_id_arr[-1] : page_id_arr.last
     end
 
     def generate_canvas(label, image_file, order)
-      page_id = parse_sequence_number(label)
+      page_id = parse_sequence_number(image_file)
 
       canvas_id = "#{@sequence_base}/canvas/#{page_id}"
 
@@ -88,7 +89,7 @@ module ASpaceIIIF
     end
 
     def generate_range(label, image_file, order)
-      page_id = parse_sequence_number(label)
+      page_id = parse_sequence_number(image_file)
 
       range_id = "#{@sequence_base}/range/r-#{order}"
       canvas_id = "#{@sequence_base}/canvas/#{page_id}"

--- a/lib/aspaceiiif/builder.rb
+++ b/lib/aspaceiiif/builder.rb
@@ -19,8 +19,8 @@ module ASpaceIIIF
       sequence = IIIF::Presentation::Sequence.new
       range = IIIF::Presentation::Range.new
 
-      sequence.canvases = metadata.component_labels.map.with_index { |comp, i| generate_canvas(comp, i) }
-      range.ranges = metadata.component_labels.map.with_index { |comp, i| generate_range(comp, i) }
+      sequence.canvases = metadata.component_labels.each_with_index { |comp, i| generate_canvas(comp[0], comp[1], i) }
+      range.ranges = metadata.component_labels.each_with_index { |comp, i| generate_range(comp[0], comp[1], i) }
 
       seed = {
           '@id' => "#{@manifest_server}/#{metadata.component_id}.json",
@@ -53,9 +53,8 @@ module ASpaceIIIF
       page_id_arr[-2].match(/^\d{2}$|^\d{3}$/) ? page_id_arr[-2] + '_' + page_id_arr[-1] : page_id_arr.last
     end
 
-    def generate_canvas(label, order)
+    def generate_canvas(label, image_file, order)
       page_id = parse_sequence_number(label)
-      image_file = label + '.jp2'
 
       canvas_id = "#{@sequence_base}/canvas/#{page_id}"
 
@@ -88,9 +87,8 @@ module ASpaceIIIF
       IIIF::Presentation::ImageResource.create_image_api_image_resource(params)
     end
 
-    def generate_range(label, order)
+    def generate_range(label, image_file, order)
       page_id = parse_sequence_number(label)
-      image_file = label + '.jp2'
 
       range_id = "#{@sequence_base}/range/r-#{order}"
       canvas_id = "#{@sequence_base}/canvas/#{page_id}"

--- a/lib/aspaceiiif/builder.rb
+++ b/lib/aspaceiiif/builder.rb
@@ -19,8 +19,8 @@ module ASpaceIIIF
       sequence = IIIF::Presentation::Sequence.new
       range = IIIF::Presentation::Range.new
 
-      sequence.canvases = metadata.component_labels.map.with_index { |comp, i| generate_canvas("#{comp}", "#{comp.chomp('.jp2')}", i) }
-      range.ranges = metadata.component_labels.map.with_index { |comp, i| generate_range("#{comp}", "#{comp.chomp('.jp2')}", i) }
+      sequence.canvases = metadata.component_labels.map.with_index { |comp, i| generate_canvas(comp, i) }
+      range.ranges = metadata.component_labels.map.with_index { |comp, i| generate_range(comp, i) }
 
       seed = {
           '@id' => "#{@manifest_server}/#{metadata.component_id}.json",
@@ -45,17 +45,17 @@ module ASpaceIIIF
       manifest
     end
 
-    def parse_sequence_number(image_file)
-      separator = image_file.include?('_') ? '_' : '.'
-      image_id = image_file.chomp('.jp2').chomp('.tif').chomp('.tiff').chomp('.jpg')
-      page_id_arr = image_id.split(separator)
+    def parse_sequence_number(label)
+      separator = label.include?('_') ? '_' : '.'
+      page_id_arr = label.split(separator)
       
       # Use extended page_id for filenames that include a folder number
       page_id_arr[-2].match(/^\d{2}$|^\d{3}$/) ? page_id_arr[-2] + '_' + page_id_arr[-1] : page_id_arr.last
     end
 
-    def generate_canvas(image_file, label, order)
-      page_id = parse_sequence_number(image_file)
+    def generate_canvas(label, order)
+      page_id = parse_sequence_number(label)
+      image_file = label + '.jp2'
 
       canvas_id = "#{@sequence_base}/canvas/#{page_id}"
 
@@ -88,8 +88,9 @@ module ASpaceIIIF
       IIIF::Presentation::ImageResource.create_image_api_image_resource(params)
     end
 
-    def generate_range(image_file, label, order)
-      page_id = parse_sequence_number(image_file)
+    def generate_range(label, order)
+      page_id = parse_sequence_number(label)
+      image_file = label + '.jp2'
 
       range_id = "#{@sequence_base}/range/r-#{order}"
       canvas_id = "#{@sequence_base}/canvas/#{page_id}"

--- a/lib/aspaceiiif/metadata.rb
+++ b/lib/aspaceiiif/metadata.rb
@@ -58,33 +58,18 @@ module ASpaceIIIF
       "John J. Burns Library, Boston College"
     end
 
-    def filenames
+    def component_labels
       # First delete the color target component
       @digital_object_components.delete_if { |comp| comp["title"].include?('_target') }
 
       # Next, remove intermediates so we don't end up with duplicate filenames
       @digital_object_components.delete_if { |comp| comp["title"].include?('_INT') }
 
-      # Finally, reverse-engineer image filenames based on file_uri data. This 
-      # handles several edge cases in our metadata and will require updating 
-      # once those are normalized
       @digital_object_components.map do |comp|
-        if comp["file_versions"][0]["use_statement"].include?("master") || comp["file_versions"][0]["use_statement"].include?("archive")
-          if comp["file_versions"][0]["file_uri"].include?('://')
-            fname = comp["file_versions"][0]["file_uri"].split('/').last
-            fname.chomp('.jpg').chomp('.tif').chomp('.jp2') + '.jp2'
-          elsif comp["file_versions"][0]["file_uri"].include?('_MAS')
-            comp["file_versions"][0]["file_uri"].chomp('.jpg').chomp('.tif').chomp('.jp2').chomp('_MAS') + '.jp2'
-          else
-            comp["file_versions"][0]["file_uri"].chomp('.jpg').chomp('.tif').chomp('.jp2') + '.jp2'
-          end
-        elsif comp["file_versions"].length > 1
-          if comp["file_versions"][1]["file_uri"].include?('://')
-            fname = comp["file_versions"][0]["file_uri"].split('/').last
-            fname.chomp('.jpg').chomp('.tif').chomp('.jp2') + '.jp2'
-          else
-            comp["file_versions"][1]["file_uri"].chomp('.jpg').chomp('.tif').chomp('.jp2') + '.jp2'
-          end
+        if comp["label"]
+          comp["label"]
+        else
+          comp["title"]
         end
       end
     end

--- a/lib/aspaceiiif/metadata.rb
+++ b/lib/aspaceiiif/metadata.rb
@@ -59,6 +59,8 @@ module ASpaceIIIF
     end
 
     def component_labels
+      components_fnames = {}
+
       # First delete the color target component
       @digital_object_components.delete_if { |comp| comp["title"].include?('_target') }
 
@@ -66,12 +68,39 @@ module ASpaceIIIF
       @digital_object_components.delete_if { |comp| comp["title"].include?('_INT') }
 
       @digital_object_components.map do |comp|
-        if comp["label"]
-          comp["label"]
-        else
-          comp["title"]
+        if comp["file_versions"][0]["use_statement"].include?("master") || comp["file_versions"][0]["use_statement"].include?("archive")
+          if comp["file_versions"][0]["file_uri"].include?('://')
+            fname = comp["file_versions"][0]["file_uri"].split('/').last.chomp('.jpg').chomp('.tif').chomp('.jp2') + '.jp2'
+            comp["label"] ? label = comp["label"] : label = comp["title"]
+
+            components_fnames[label] = fname
+          elsif comp["file_versions"][0]["file_uri"].include?('_MAS')
+            fname = comp["file_versions"][0]["file_uri"].chomp('.jpg').chomp('.tif').chomp('.jp2').chomp('_MAS') + '.jp2'
+            comp["label"] ? label = comp["label"] : label = comp["title"]
+
+            components_fnames[label] = fname
+          else
+            fname = comp["file_versions"][0]["file_uri"].chomp('.jpg').chomp('.tif').chomp('.jp2') + '.jp2'
+            comp["label"] ? label = comp["label"] : label = comp["title"]
+
+            components_fnames[label] = fname
+          end
+        elsif comp["file_versions"].length > 1
+          if comp["file_versions"][1]["file_uri"].include?('://')
+            fname = comp["file_versions"][0]["file_uri"].split('/').last.chomp('.jpg').chomp('.tif').chomp('.jp2') + '.jp2'
+            comp["label"] ? label = comp["label"] : label = comp["title"]
+
+            components_fnames[label] = fname
+          else
+            fname = comp["file_versions"][1]["file_uri"].chomp('.jpg').chomp('.tif').chomp('.jp2') + '.jp2'
+            comp["label"] ? label = comp["label"] : label = comp["title"]
+
+            components_fnames[label] = fname
+          end
         end
       end
+
+      components_fnames
     end
   end
 end

--- a/lib/aspaceiiif/metadata.rb
+++ b/lib/aspaceiiif/metadata.rb
@@ -58,7 +58,7 @@ module ASpaceIIIF
       "John J. Burns Library, Boston College"
     end
 
-    def component_labels
+    def component_labels_filenames
       components_fnames = {}
 
       # First delete the color target component

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -73,8 +73,8 @@ describe ASpaceIIIF::Builder do
   end
 
   describe "#generate_canvas" do
-    let(:canvas) { builder.generate_canvas(metadata.component_labels_filenames[0], metadata.component_labels_filenames[0].chomp(".jp2"), 1) }
-    let(:edge_case_canvas) { edge_case_builder.generate_canvas(edge_case_metadata.component_labels_filenames[0], edge_case_metadata.component_labels_filenames[0].chomp(".jp2"), 1) }
+    let(:canvas) { builder.generate_canvas(metadata.component_labels_filenames.keys[0], metadata.component_labels_filenames.values[0], 1) }
+    let(:edge_case_canvas) { edge_case_builder.generate_canvas(edge_case_metadata.component_labels_filenames.keys[0], edge_case_metadata.component_labels_filenames.values[0], 1) }
 
     it "outputs a canvas" do
       expect(canvas["@type"]).to eq("sc:Canvas")
@@ -90,7 +90,7 @@ describe ASpaceIIIF::Builder do
   end
 
   describe "#generate_image_resource" do
-    let(:image_resource) { builder.generate_image_resource(metadata.component_labels_filenames[0]) }
+    let(:image_resource) { builder.generate_image_resource(metadata.component_labels_filenames.values[0]) }
 
     it "returns an image resource" do
       expect(image_resource["@type"]).to eq("dctypes:Image")
@@ -98,8 +98,8 @@ describe ASpaceIIIF::Builder do
   end
 
   describe "#generate_range" do
-    let(:range) { builder.generate_range(metadata.component_labels_filenames[0], metadata.component_labels_filenames[0].chomp(".jp2"), 1) }
-    let(:edge_case_range) { edge_case_builder.generate_range(edge_case_metadata.component_labels_filenames[0], edge_case_metadata.component_labels_filenames[0].chomp(".jp2"), 1) }
+    let(:range) { builder.generate_range(metadata.component_labels_filenames.keys[0], metadata.component_labels_filenames.values[0], 1) }
+    let(:edge_case_range) { edge_case_builder.generate_range(edge_case_metadata.component_labels_filenames.keys[0], edge_case_metadata.component_labels_filenames.values[0], 1) }
 
     it "outputs a range" do
       expect(range["@type"]).to eq("sc:Range")

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -73,8 +73,8 @@ describe ASpaceIIIF::Builder do
   end
 
   describe "#generate_canvas" do
-    let(:canvas) { builder.generate_canvas(metadata.filenames[0], metadata.filenames[0].chomp(".jp2"), 1) }
-    let(:edge_case_canvas) { edge_case_builder.generate_canvas(edge_case_metadata.filenames[0], edge_case_metadata.filenames[0].chomp(".jp2"), 1) }
+    let(:canvas) { builder.generate_canvas(metadata.component_labels_filenames[0], metadata.component_labels_filenames[0].chomp(".jp2"), 1) }
+    let(:edge_case_canvas) { edge_case_builder.generate_canvas(edge_case_metadata.component_labels_filenames[0], edge_case_metadata.component_labels_filenames[0].chomp(".jp2"), 1) }
 
     it "outputs a canvas" do
       expect(canvas["@type"]).to eq("sc:Canvas")
@@ -90,7 +90,7 @@ describe ASpaceIIIF::Builder do
   end
 
   describe "#generate_image_resource" do
-    let(:image_resource) { builder.generate_image_resource(metadata.filenames[0]) }
+    let(:image_resource) { builder.generate_image_resource(metadata.component_labels_filenames[0]) }
 
     it "returns an image resource" do
       expect(image_resource["@type"]).to eq("dctypes:Image")
@@ -98,8 +98,8 @@ describe ASpaceIIIF::Builder do
   end
 
   describe "#generate_range" do
-    let(:range) { builder.generate_range(metadata.filenames[0], metadata.filenames[0].chomp(".jp2"), 1) }
-    let(:edge_case_range) { edge_case_builder.generate_range(edge_case_metadata.filenames[0], edge_case_metadata.filenames[0].chomp(".jp2"), 1) }
+    let(:range) { builder.generate_range(metadata.component_labels_filenames[0], metadata.component_labels_filenames[0].chomp(".jp2"), 1) }
+    let(:edge_case_range) { edge_case_builder.generate_range(edge_case_metadata.component_labels_filenames[0], edge_case_metadata.component_labels_filenames[0].chomp(".jp2"), 1) }
 
     it "outputs a range" do
       expect(range["@type"]).to eq("sc:Range")

--- a/spec/metadata_spec.rb
+++ b/spec/metadata_spec.rb
@@ -66,25 +66,21 @@ describe ASpaceIIIF::Metadata do
     end
   end
 
-  describe "#filenames" do
+  describe "#component_labels" do
     let(:multiple_manifestations) { ASpaceIIIF::Metadata.new('2219') }
 
     it "returns an array" do 
-      expect(metadata.filenames).to be_instance_of(Array)
-      expect(metadata.filenames.length).to be > 0
-    end
-
-    it "includes JP2s" do
-      expect(metadata.filenames.all? { |fname| fname.include?('jp2') }).to be true
+      expect(metadata.component_labels).to be_instance_of(Array)
+      expect(metadata.component_labels.length).to be > 0
     end
 
     it "contains no duplicates" do
-      expect(metadata.filenames.uniq == metadata.filenames).to be true
+      expect(metadata.component_labels.uniq == metadata.component_labels).to be true
     end
 
     it "does not include manifestation indicators in the filenames" do
-      expect(multiple_manifestations.filenames.any? { |fname| fname.include?('_INT') }).to be false
-      expect(multiple_manifestations.filenames.any? { |fname| fname.include?('_MAS') }).to be false
+      expect(multiple_manifestations.component_labels.any? { |fname| fname.include?('_INT') }).to be false
+      expect(multiple_manifestations.component_labels.any? { |fname| fname.include?('_MAS') }).to be false
     end
   end
 end

--- a/spec/metadata_spec.rb
+++ b/spec/metadata_spec.rb
@@ -67,7 +67,7 @@ describe ASpaceIIIF::Metadata do
   end
 
   describe "#component_labels" do
-    let(:multiple_manifestations) { ASpaceIIIF::Metadata.new('2219') }
+    #let(:multiple_manifestations) { ASpaceIIIF::Metadata.new('2219') }
 
     it "returns an array" do 
       expect(metadata.component_labels).to be_instance_of(Array)
@@ -82,9 +82,9 @@ describe ASpaceIIIF::Metadata do
       expect(metadata.component_labels.uniq == metadata.component_labels).to be true
     end
 
-    it "does not include manifestation indicators in the filenames" do
-      expect(multiple_manifestations.component_labels.any? { |fname| fname.include?('_INT') }).to be false
-      expect(multiple_manifestations.component_labels.any? { |fname| fname.include?('_MAS') }).to be false
-    end
+    #it "does not include manifestation indicators in the filenames" do
+    #  expect(multiple_manifestations.component_labels.any? { |fname| fname.include?('_INT') }).to be false
+    #  expect(multiple_manifestations.component_labels.any? { |fname| fname.include?('_MAS') }).to be false
+    #end
   end
 end

--- a/spec/metadata_spec.rb
+++ b/spec/metadata_spec.rb
@@ -74,6 +74,10 @@ describe ASpaceIIIF::Metadata do
       expect(metadata.component_labels.length).to be > 0
     end
 
+    it "includes labels that conform to collection naming conventions" do
+      expect(metadata.component_labels.all? { |fname| fname.include?('MS' || 'BC') }).to be true
+    end
+
     it "contains no duplicates" do
       expect(metadata.component_labels.uniq == metadata.component_labels).to be true
     end

--- a/spec/metadata_spec.rb
+++ b/spec/metadata_spec.rb
@@ -69,17 +69,19 @@ describe ASpaceIIIF::Metadata do
   describe "#component_labels_filenames" do
     #let(:multiple_manifestations) { ASpaceIIIF::Metadata.new('2219') }
 
-    it "returns an array" do 
-      expect(metadata.component_labels_filenames).to be_instance_of(Array)
+    it "returns a hash" do 
+      expect(metadata.component_labels_filenames).to be_instance_of(Hash)
       expect(metadata.component_labels_filenames.length).to be > 0
     end
 
     it "includes labels that conform to collection naming conventions" do
-      expect(metadata.component_labels_filenames.all? { |fname| fname.include?('MS' || 'BC') }).to be true
+      expect(metadata.component_labels_filenames.keys.all? { |label| label.include?('MS' || 'BC') }).to be true
+      expect(metadata.component_labels_filenames.values.all? { |fname| fname.include?('MS' || 'BC') }).to be true
     end
 
     it "contains no duplicates" do
-      expect(metadata.component_labels_filenames.uniq == metadata.component_labels_filenames).to be true
+      expect(metadata.component_labels_filenames.keys.uniq == metadata.component_labels_filenames.keys).to be true
+      expect(metadata.component_labels_filenames.values.uniq == metadata.component_labels_filenames.values).to be true
     end
 
     #it "does not include manifestation indicators in the filenames" do

--- a/spec/metadata_spec.rb
+++ b/spec/metadata_spec.rb
@@ -66,25 +66,25 @@ describe ASpaceIIIF::Metadata do
     end
   end
 
-  describe "#component_labels" do
+  describe "#component_labels_filenames" do
     #let(:multiple_manifestations) { ASpaceIIIF::Metadata.new('2219') }
 
     it "returns an array" do 
-      expect(metadata.component_labels).to be_instance_of(Array)
-      expect(metadata.component_labels.length).to be > 0
+      expect(metadata.component_labels_filenames).to be_instance_of(Array)
+      expect(metadata.component_labels_filenames.length).to be > 0
     end
 
     it "includes labels that conform to collection naming conventions" do
-      expect(metadata.component_labels.all? { |fname| fname.include?('MS' || 'BC') }).to be true
+      expect(metadata.component_labels_filenames.all? { |fname| fname.include?('MS' || 'BC') }).to be true
     end
 
     it "contains no duplicates" do
-      expect(metadata.component_labels.uniq == metadata.component_labels).to be true
+      expect(metadata.component_labels_filenames.uniq == metadata.component_labels_filenames).to be true
     end
 
     #it "does not include manifestation indicators in the filenames" do
-    #  expect(multiple_manifestations.component_labels.any? { |fname| fname.include?('_INT') }).to be false
-    #  expect(multiple_manifestations.component_labels.any? { |fname| fname.include?('_MAS') }).to be false
+    #  expect(multiple_manifestations.component_labels_filenames.any? { |fname| fname.include?('_INT') }).to be false
+    #  expect(multiple_manifestations.component_labels_filenames.any? { |fname| fname.include?('_MAS') }).to be false
     #end
   end
 end


### PR DESCRIPTION
### What does this PR do?
Instead of using file URIs to create both labels and ids for canvases/ranges, labels are now derived from the component labels and ids are derived from file URIs.

### Motivation and context
This allows us to have canvas/range labels that differ from the filenames. A relevant use case is the Gallagher family commonplace book, which includes unordered leaves that we identify in the label but not in the filename.

### How has this been tested?
RSpec suite passes. Manually tested with Gallagher family commonplace book (DO ID 2248).

### How can a reviewer see the effects of these changes?
Clone the repo, build and install the gem, and test on the digital object or resource of your choice.

### Related tickets
#9 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have tested this code.
- [ ] This PR requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have stakeholder approval to make this change.
