### PR TITLE
Add extra step to gem installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,13 @@ this repository:
     $ git clone https://github.com/BCDigLib/aspaceiiif
     $ cd aspaceiiif
 
-Update the settings in example_config.yml according to your ArchivesSpace instance, rename 
-that file to config.yml, then build and install the gem:
+Update the settings in example_config.yml according to your ArchivesSpace instance and rename 
+that file to config.yml. Then, add the changes to Git, so it knows that example_config.yml no 
+longer exists (this is necessary because the gemspec uses git ls-files):
+
+    $ git add .
+
+You can now build and install the gem:
 
     $ gem build aspaceiiif.gemspec
     $ gem install aspaceiiif-x.x.x.gem


### PR DESCRIPTION
### What does this PR do?
Updates installation instructions in README.md.

### Motivation and context
Now that the config file is named `example_config.yml`, the build process fails once we rename that file back to `config.yml`. This is because `aspaceiiif.gemspec` uses `git ls-files` to look for files to add to the gemspec.

A more sane way to do this would be to add `example_config.yml` to the `reject` block in that part of the gemspec, but I couldn't get that to work and wanted to make sure I got this documented.

### How has this been tested?
N/A (documentation).

### How can a reviewer see the effects of these changes?
Look at the readme.

### Related tickets
<!--- Please link to the Trello card or GitHub issue here -->

### Screenshots
<!-- Include relevant screenshots if necessary -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [ ] I have tested this code.
- [x] This PR requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have stakeholder approval to make this change.
