### PR TITLE
Add config.yml to spec.files

### DIFF
--- a/aspaceiiif.gemspec
+++ b/aspaceiiif.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
+  spec.files << "config.yml"
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
### What does this PR do?
Adds `config.yml` to the `files` array in the gemspec.

### Motivation and context
This is necessary now that `config.yml` is in `.gitignore`, as the gemspec uses `git ls-files` to populate the `files` array.

### How has this been tested?
Built and installed the gem successfully without Ruby yelling about missing files.

### How can a reviewer see the effects of these changes?
Confirm that you can build and install with this commit.

### Related tickets
<!--- Please link to the Trello card or GitHub issue here -->

### Screenshots
<!-- Include relevant screenshots if necessary -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have tested this code.
- [ ] This PR requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have stakeholder approval to make this change.
