### PR TITLE
Improve edge case handling in Metadata class

### DIFF
--- a/lib/aspaceiiif/metadata.rb
+++ b/lib/aspaceiiif/metadata.rb
@@ -69,9 +69,26 @@ module ASpaceIIIF
       @digital_object_components.delete_if { |comp| comp["title"].include?('_INT') }
 
       # Finally, map labels to filenames, accounting for various quirks
-      # TODO: refactor for simplicity once we rebuild legacy DOs
+      # TODO: refactor for simplicity and clarity once we rebuild legacy DOs
       @digital_object_components.map do |comp|
         if comp["file_versions"][0]["use_statement"].include?("master") || comp["file_versions"][0]["use_statement"].include?("archive")
+          if comp["file_versions"][0]["file_uri"].include?('://')
+            fname = comp["file_versions"][0]["file_uri"].split('/').last.chomp('.jpg').chomp('.tif').chomp('.jp2') + '.jp2'
+            comp["label"] ? label = comp["label"] : label = comp["title"]
+
+            components_fnames[label] = fname
+          elsif comp["file_versions"][0]["file_uri"].include?('_MAS')
+            fname = comp["file_versions"][0]["file_uri"].chomp('.jpg').chomp('.tif').chomp('.jp2').chomp('_MAS') + '.jp2'
+            comp["label"] ? label = comp["label"] : label = comp["title"]
+
+            components_fnames[label] = fname
+          else
+            fname = comp["file_versions"][0]["file_uri"].chomp('.jpg').chomp('.tif').chomp('.jp2') + '.jp2'
+            comp["label"] ? label = comp["label"] : label = comp["title"]
+
+            components_fnames[label] = fname
+          end
+        elsif comp["file_versions"].length == 1 && comp["file_versions"][0]["use_statement"].include?("access_copy")
           if comp["file_versions"][0]["file_uri"].include?('://')
             fname = comp["file_versions"][0]["file_uri"].split('/').last.chomp('.jpg').chomp('.tif').chomp('.jp2') + '.jp2'
             comp["label"] ? label = comp["label"] : label = comp["title"]

--- a/lib/aspaceiiif/metadata.rb
+++ b/lib/aspaceiiif/metadata.rb
@@ -10,6 +10,7 @@ module ASpaceIIIF
       @archival_object = as_records.archival_object
       @resource = as_records.resource
       @linked_agent = as_records.linked_agent
+      @digital_object_pk = dig_obj_id
     end
 
     def handle
@@ -46,6 +47,8 @@ module ASpaceIIIF
         @archival_object["component_id"]
       elsif handle.include?('BC') || handle.include?('MS')
         handle.split('/').last
+      else
+        raise "Digital object #{@digital_object_pk} has no corresponding component unique ID."
       end
     end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### What does this PR do?
Two small changes to the Metadata class:
1. Updates component_labels_filenames method to account for digital object components that only have access copy file versions and no archive/master use statement.
2. Raises an error if there's no component unique identifier in the parent archival object record or digital object handle suffix.

### Motivation and context
The additional exception handling is intended to minimize confusion. Since the gem requires a component unique identifier to appear either in the AO or the DO's handle suffix, there's no reason for it to run if it doesn't find a CUID.

The change to component_labels_filenames is to accommodate a fairly rare use case when we only have access copies for a digital object. Previously, this method ignored all use statements other than 'archive' or 'master'. Ideally, we'd like all of our digital objects to have an archive/master manifestation, but this is not the case with some legacy collections.

### How has this been tested?
Tested with DOs without CUIDs and with CUIDs, and it works as intended. (Could not test with a DO with just an access_copy manifestation, because the only example available also had no CUID.)

### How can a reviewer see the effects of these changes?
Clone the repo, build and install the gem, and try running it on a digital object (or resource with descendant digital objects) that do not have an associated CUID.

### Related tickets
<!--- Please link to the Trello card or GitHub issue here -->

### Screenshots
<!-- Include relevant screenshots if necessary -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have tested this code.
- [x] This PR requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have stakeholder approval to make this change.
