### PR TITLE
Update to use O'Sullivan v1.0. Fixes #17

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,22 +6,28 @@ support Boston College Libraries' IIIF implementation.
 
 ## Installation
 
-To use the command line tool you will need to install locally. Clone or download
-this repository:
+To use the command line tool you will need to install locally. First, make sure any old versions of the gem have been removed:
+
+    $ gem uninstall aspaceiiif
+
+Clone or download this repository:
 
     $ git clone https://github.com/BCDigLib/aspaceiiif
     $ cd aspaceiiif
 
-Update the settings in example_config.yml according to your ArchivesSpace instance and rename 
-that file to config.yml. Then, add the changes to Git, so it knows that example_config.yml no 
-longer exists (this is necessary because the gemspec uses git ls-files):
+Make a copy of _example_config.yml_ named _config.yml_:
+
+    $ cp example_config.yml config.yml
+   
+Edit _config.yml_ according to your ArchivesSpace instance. Add the changes to Git (this is necessary
+ because the gemspec uses git ls-files):
 
     $ git add .
 
 You can now build and install the gem:
 
     $ gem build aspaceiiif.gemspec
-    $ gem install aspaceiiif-x.x.x.gem
+    $ gem install aspaceiiif-0.3.1.gem
 
 ## Usage
 

--- a/aspaceiiif.gemspec
+++ b/aspaceiiif.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'iiif-presentation', "~> 0.2"
+  spec.add_runtime_dependency 'iiif-presentation', "~> 1.0"
   spec.add_runtime_dependency 'json', "~> 2.0.0"
   spec.add_runtime_dependency 'rest-client', "~> 2.0.0"
 

--- a/lib/aspaceiiif/version.rb
+++ b/lib/aspaceiiif/version.rb
@@ -1,3 +1,3 @@
 module ASpaceIIIF
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end


### PR DESCRIPTION
### What does this PR do?

This PR updates the gem to use O'Sullivan v1.0 and contains updated installation instructions.

### Motivation and context

Faraday was recently updated to version 1.0. This was a breaking error. O'Sullivan depends on Faraday but does not put a bound on the version to install, so this change broke new installs of aspaceiiif with the error:

    Adapter should be set using the `adapter` method, not `use` (RuntimeError)

### How has this been tested?

I processed a few DOs.

### How can a reviewer see the effects of these changes?

Uninstall any old aspaceiiif installs, install from the update-osullivan branch, and process a DO. Behold it not crash.

### Related tickets

In response to #17.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [x] I have tested this code.
- [x] This PR requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have stakeholder approval to make this change.
